### PR TITLE
v0.4.0

### DIFF
--- a/main.js
+++ b/main.js
@@ -221,6 +221,7 @@ function generatePresence() {
 
                 // Gets the users current status
                 let currentlyPlaying = document.getElementsByClassName("HDKZKb  LiQ6Hb");
+                let controllerMenu = document.getElementsByClassName("hpog5e");
 
                 // Disconnects StadiaRPC if the page isn't loaded
                 if (currentlyPlaying === undefined) {
@@ -234,10 +235,14 @@ function generatePresence() {
                     }
                 }
 
-                if (currentlyPlaying.slice(0, 7) === "Playing") {
-                    detailDisplay = currentlyPlaying;
-                    largeImgTxt = currentlyPlaying.slice(8);
-                    smallImg = "chrome";
+                // Ensure controller connect dialog is not open
+                if (controllerMenu.length === 0)
+                {
+                  if (currentlyPlaying.slice(0, 7) === "Playing") {
+                      detailDisplay = currentlyPlaying;
+                      largeImgTxt = currentlyPlaying.slice(8);
+                      smallImg = "chrome";
+                  }
                 }
 
                 // Extracts the id from the game currently being played

--- a/main.js
+++ b/main.js
@@ -6,6 +6,7 @@ let rpcDb = {};
 //Establish settings
 let homeOn = true;
 let storeOn = true;
+let captureOn = true;
 let gameOn = true;
 let ccOn = false;
 
@@ -21,11 +22,12 @@ let ccOn = false;
     games = await response.json();
 
     // Get settings
-    chrome.storage.local.get({rpcHomeOn: true, rpcStoreOn: true, rpcGameOn: true, rpcCCOn: false}, function(items) {
+    chrome.storage.local.get({rpcHomeOn: true, rpcStoreOn: true, rpcCaptureOn: true, rpcGameOn: true, rpcCCOn: false}, function(items) {
         homeOn = items.rpcHomeOn;
         storeOn = items.rpcStoreOn;
         gameOn = items.rpcGameOn;
         ccOn = items.rpcCCOn;
+        captureOn = items.rpcCaptureOn;
 
         //Register presence after getting settings
         chrome.runtime.sendMessage(extensionId, { mode: 'active' }, function (response) {
@@ -51,8 +53,8 @@ chrome.runtime.onMessage.addListener(function (info, sender, sendResponse) {
 });
 
 //Establish all options
-let largeImgTxt = "";
-let smallImgTxt = "Stadia (Chrome)";
+let largeImgTxt = "Stadia";
+let smallImgTxt = "Chrome";
 let largeImg = "stadialogosquare";
 let smallImg = "chrome";
 let detailDisplay = "Using Stadia";
@@ -61,25 +63,43 @@ let clientId = "648430151390199818"; // Default Application ID, sets game as "St
 let stateDisplay = "";
 let time = Date.now();
 
-let prevUrl = location.href;
+let prevImgTxt = largeImgTxt; // cover ALL game status changes (including Chromecast/Pixel)
+let prevUrl = location.href; // cover status changes to URLs (i.e., store)
+let previousDetail = detailDisplay; //cover changes to viewing/browsing captures
 
 function generatePresence() {
         try {
             const tabURL = location.href;
+            const captureViewerDisplayed = document.querySelector(".tNaJ7");
+
             clientId = "648430151390199818";
 
             if (tabURL.includes("home")) {
                 console.log(tabURL)
-                detailDisplay = "Home Page";
-                largeImgTxt = "On Stadia Home";
+                detailDisplay = "On home page";
+                largeImgTxt = "Stadia Home";
                 largeImg = "stadialogosquare";
                 smallImg = "chrome";
-                
+
+                if (captureOn && captureViewerDisplayed)
+                {
+                  detailDisplay = "Viewing a capture"
+                  smallImgTxt = "Chrome"
+                }
+
                 if (ccOn) {
+                    //make sure we're not viewing a capture on home page
+                    if ((!captureViewerDisplayed && captureOn) || !captureOn)
+                    {
+                      // ccOn can always be enabled, so just show as online for now
+                      smallImg = "online";
+                      smallImgTxt = "";
+                      detailDisplay = "Home";
+                    }
 
                     // Gets the users current status
                     let currentlyPlaying = document.getElementsByClassName("HDKZKb  LiQ6Hb");
-                    
+
                     // Disconnects StadiaRPC if the page isn't loaded
                     if (currentlyPlaying === undefined) {
                         return {'action': 'disconnect'}
@@ -92,30 +112,61 @@ function generatePresence() {
                         }
                     }
 
-                    if (currentlyPlaying.slice(0, 7) === "Playing") {
+                  if (currentlyPlaying.slice(0, 7) === "Playing" && !prevUrl.includes("player") && !captureViewerDisplayed) {
                         detailDisplay = currentlyPlaying;
-                        smallImgTxt = "on Stadia"
+                        largeImgTxt = currentlyPlaying.slice(8)
+                        smallImgTxt = ""; //Casting
 
                         //Slice to just game name then make lowercase and remove special characters
-                        currentlyPlaying = currentlyPlaying.slice(8).toLowerCase().replace(/[^a-z0-9]/g, "");
-                        
+                        currentlyPlayingLower = currentlyPlaying.slice(8).toLowerCase().replace(/[^a-z0-9]/g, "");
+
                         Object.keys(games).forEach(gameName => {
                             let game = games[gameName];
                             game["aliases"].forEach(alias => {
-                                if (alias === currentlyPlaying) {
+                                if (alias === currentlyPlayingLower) {
                                     largeImgTxt = gameName;
-                                    
+
                                     if (game["hasIcon"]) {
                                         largeImg = game["aliases"][0];
                                         smallImg = "stadialogosquare";
-
-                                    } else {
-                                        largeImg = "stadialogosquare";
-                                        smallImg = "online"
+                                        smallImgTxt = "Stadia";
                                     }
                                 }
                             });
                         });
+
+                        // Assume last played game is what is currently being played on Chromecast or Android
+                        let currentlyPlayingId = document.querySelector(".n4qZSd.fcUT2e").getAttribute("data-app-id");
+                        currentlyPlaying = currentlyPlaying.slice(8)
+
+                        // For every game in the DB
+                        gamesDb.forEach(function(dbGame) {
+                            let dbGameId = dbGame[0].split("'")[1] // Grabs just the store link
+                            dbGameId = dbGameId.split("/")[5] // Grabs the GameID from the DB's store link
+
+                            let dbGameName = dbGame[1];
+                            if (currentlyPlayingId === dbGameId && currentlyPlaying === dbGameName) {
+                                detailDisplay = "Playing " + dbGameName;
+                                largeImgTxt = dbGameName;
+                                smallImgTxt = ""; //Casting
+
+                                // Checking for icon and setting it if it's there
+                                if (rpcDb["gamesWithIcon"].includes(dbGameName)) {
+                                    largeImg = dbGameName.toLowerCase().replace(/[^a-z0-9]/g, "");
+                                    smallImg = "stadialogosquare";
+                                    smallImgTxt = "Stadia";
+
+                                // Checking for Custom Application ID
+                                } else if (Object.keys(rpcDb["gamesWithCustomApp"]).includes(dbGameName)) {
+                                    smallImg = "stadialogosquare";
+                                    largeImg = dbGameName.toLowerCase().replace(/[^a-z0-9]/g, "");
+                                    clientId = rpcDb["gamesWithCustomApp"][dbGameName];
+                                    smallImgTxt = "Stadia";
+                                    detailDisplay = "Playing on Stadia";
+                                }
+                            }
+                        });
+
                     } else if (!homeOn) {
                         return {action: "disconnect"};
                     }
@@ -124,12 +175,13 @@ function generatePresence() {
                 if (!homeOn && !ccOn) {
                     return {action: "disconnect"};
                 }
-                
+
             } else if (tabURL.includes("store")) {
-                detailDisplay = "Browsing the Store";
-                largeImgTxt = "Looking for Something New";
+                detailDisplay = "Browsing the store";
+                largeImgTxt = "Stadia Store";
                 largeImg = "stadialogosquare";
                 smallImg = "chrome";
+                smallImgTxt = "Chrome";
 
                 if (!storeOn) {
                     return {action: "disconnect"};
@@ -139,70 +191,115 @@ function generatePresence() {
                 const currentlyViewingSku = splitUrl[splitUrl.length - 1]
                 const currentlyViewingId = splitUrl[splitUrl.length - 3]
 
+                // bundle pages exist, so let's try to catch some... page title is the easiest fallback
+                let gameTitle = document.title.replace(" - Store - Stadia","").replace("®","").replace("™","").replace("©","");
+                //used to tell when at end of the foreach below
+                let gameCount = 0;
+
                 gamesDb.forEach(function(dbGame) {
                     let dbStoreLink = dbGame[0].split("'")[1]
                     let dbGameId = dbStoreLink.split("/")[5] // Grabs the GameID from the DB's store link
-                    let dbGameSku = dbStoreLink.split("/")[7] // Grabs the GameID from the DB's store link
-                    
+                    let dbGameSku = dbStoreLink.split("/")[7] // Grabs the GameSKU from the DB's store link
+
                     if (currentlyViewingId === dbGameId && currentlyViewingSku === dbGameSku) {
-
-                        largeImgTxt = "Browsing the Store";
-                        detailDisplay = "Checking out " + dbGame[1];
-
+                        detailDisplay = "Viewing " + dbGame[1];
+                    } else if (dbGame[1] === gameTitle) {
+                        //only if exact match... instead of dbGame[1].contains("DOOM"), plus "Stadia" or "Gold" editions, etc.
+                        detailDisplay = "Viewing " + dbGame[1];
+                    } else if (gameCount === dbGame.length - 1 && tabURL.includes("store/details")) {
+                        //last item in foreach, still no match, use page title instead of gamesDB
+                        detailDisplay = "Viewing " + gameTitle;
                     }
+                    gameCount++;
                 });
-            
+
             } else if (tabURL.includes("player")) {
 
                 if (!gameOn) {
                     return {action: "disconnect"};
                 }
 
+                // Gets the users current status
+                let currentlyPlaying = document.getElementsByClassName("HDKZKb  LiQ6Hb");
+
+                // Disconnects StadiaRPC if the page isn't loaded
+                if (currentlyPlaying === undefined) {
+                    return {'action': 'disconnect'}
+                }
+
+                for (let i = 0; i < currentlyPlaying.length; i++) {
+                    if (!currentlyPlaying[i].getAttribute("class").includes("FW3qke")) {
+                        currentlyPlaying = currentlyPlaying[i].textContent;
+                        break;
+                    }
+                }
+
+                if (currentlyPlaying.slice(0, 7) === "Playing") {
+                    detailDisplay = currentlyPlaying;
+                    largeImgTxt = currentlyPlaying.slice(8);
+                    smallImg = "chrome";
+                }
+
                 // Extracts the id from the game currently being played
                 let currentlyPlayingId = tabURL.split("/");
                 currentlyPlayingId = currentlyPlayingId[currentlyPlayingId.length - 1]
+                smallImgTxt = "Chrome";
 
-                //For every game in the DB
+                //For every game in the DB'
                 gamesDb.forEach(function(dbGame) {
                     let dbGameId = dbGame[0].split("'")[1] // Grabs just the store link
                     dbGameId = dbGameId.split("/")[5] // Grabs the GameID from the DB's store link
 
                     if (currentlyPlayingId === dbGameId) {
                         let dbGameName = dbGame[1];
-
                         detailDisplay = "Playing " + dbGameName;
                         largeImgTxt = dbGameName;
-                        smallImgTxt = "On Stadia (Chrome)";
                         smallImg = "chrome";
 
                         // Checking for icon and setting it if it's there
                         if (rpcDb["gamesWithIcon"].includes(dbGameName)) {
                             largeImg = dbGameName.toLowerCase().replace(/[^a-z0-9]/g, "");
-                        
+
                         // Checking for Custom Application ID
                         } else if (Object.keys(rpcDb["gamesWithCustomApp"]).includes(dbGameName)) {
-
                             largeImg = dbGameName.toLowerCase().replace(/[^a-z0-9]/g, "");
                             clientId = rpcDb["gamesWithCustomApp"][dbGameName];
                             detailDisplay = "Playing on Stadia";
-
+                            smallImgTxt = "Chrome";
                         }
                     }
                 });
+            } else if (tabURL.includes("/captures")) {
+
+                detailDisplay = "Browsing captures";
+                largeImgTxt = "Stadia Captures";
+                largeImg = "stadialogosquare";
+                smallImg = "chrome";
+                smallImgTxt = "Chrome";
+
+                if (captureViewerDisplayed) {
+                  detailDisplay = "Viewing a capture"
+                }
+
+                if (!captureOn) {
+                    return {action: "disconnect"};
+                }
+
             }
 
             //Check to see if presence has changed, resets time if so
-            if (prevUrl !== tabURL) {
+            if (prevUrl !== tabURL || prevImgTxt !== largeImgTxt || detailDisplay !== previousDetail) {
                 time = Date.now();
             }
-
+            previousDetail = detailDisplay;
+            prevImgTxt = largeImgTxt;
             prevUrl = tabURL;
 
             //Multi-line drifting
             stateDisplay = ""
-            if (detailDisplay.length > 25) {
+            if (detailDisplay.length > 23) {
                 for (i = detailDisplay.length - 1; i >= 0; i--) {
-                    if ((detailDisplay[i] === " " || detailDisplay[i] === ":") && detailDisplay.slice(0, i + 1).length < 25) {
+                    if ((detailDisplay[i] === " " || detailDisplay[i] === ":") && detailDisplay.slice(0, i + 1).length < 23) {
                         stateDisplay = detailDisplay.slice(i + 1);
                         detailDisplay = detailDisplay.slice(0, i + 1);
                         break;
@@ -219,11 +316,11 @@ function generatePresence() {
                     instance: true,
                     largeImageKey: largeImg,
                     smallImageKey: smallImg,
-                    largeImageText: largeImgTxt,    
+                    largeImageText: largeImgTxt,
                     smallImageText: smallImgTxt
                 }
             });
-            
+
             return {
                 clientId: clientId,
                 presence: {

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "StadiaRPC",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "description": "Updates Discord rich presence to show what you're playing.",
     "manifest_version": 2,
     "permissions": [

--- a/popup.css
+++ b/popup.css
@@ -2,7 +2,7 @@
 body {
     background-color: #202124;
     width: 225px;
-    height: 325px;
+    height: 375px;
 }
 
 #container {
@@ -47,7 +47,7 @@ a:hover {
     opacity: 50%;
 }
 
-.imgLink:hover { 
+.imgLink:hover {
     opacity: 0.7;
     cursor: pointer;
 }
@@ -73,6 +73,8 @@ a:hover {
 #mainPage {
     float: left;
     width: 225px;
+    margin-top: 5px;
+    margin-bottom: 5px;
 }
 
 /* HEADER (obviously) */
@@ -105,7 +107,7 @@ a:hover {
 
 /* FOOTER */
 #footer {
-    margin-top: 32px;
+    margin-top: 75px;
     align-items: center;
 }
 
@@ -127,6 +129,8 @@ a:hover {
 #settingsPage {
     margin-left: 240px;
     width: 225px;
+    margin-top: 5px;
+    margin-bottom: 5px;
 }
 
 #settingsPage > div > p {
@@ -142,7 +146,7 @@ a:hover {
 
 #settingsPage > div:not(#homeSettings) {
     display: block;
-    box-sizing: border-box; 
+    box-sizing: border-box;
     margin-top: 25px;
 }
 

--- a/popup.html
+++ b/popup.html
@@ -12,7 +12,7 @@
                     <img class="center" height=100 src="/assets/fullicon.png">
                 </div>
                 <div id = "issues">
-                    <p id="issuesText">Support</p> 
+                    <p id="issuesText">Support</p>
                     <div id="issuesImgs">
                         <a href="https://discord.gg/zU9HFm7" target='_newtab'>
                             <img id="discordLogo" height=32px class="center imgLink" src="/assets/Discord-Logo-White.png">
@@ -38,11 +38,18 @@
                         <img id="homeToggle" height=24px class="imgLink" src="assets/rpcOff.png">
                     </p>
                 </div>
-                
+
                 <div id="storeSettings">
                     <p>
                         Store
                         <img id="storeToggle" height=24px class="imgLink" src="assets/rpcOff.png">
+                    </p>
+                </div>
+
+                <div id="captureSettings">
+                    <p>
+                        Captures
+                        <img id="captureToggle" height=24px class="imgLink" src="assets/rpcOff.png">
                     </p>
                 </div>
 
@@ -55,7 +62,7 @@
 
                 <div id="ccSettings">
                     <p>
-                        Chromecast/Pixel <a id="wiki" href="#">(?)</a>
+                        Chromecast/Mobile <a id="wiki" href="#">(?)</a>
                         <img id="ccToggle" height=24px class="imgLink" src="/assets/rpcOff.png">
                     </p>
                 </div>

--- a/popup.js
+++ b/popup.js
@@ -1,12 +1,12 @@
 document.addEventListener('DOMContentLoaded', function () {
-    
+
     //Set version #
     document.getElementById("signature").innerHTML = "soapless (" + chrome.runtime.getManifest()["version"] + ")";
 
     let mainPage = document.getElementById("mainPage");
     let settingsPage = document.getElementById("settingsPage");
     document.getElementById("settings").addEventListener("click", function() {
-        
+
         mainPage.setAttribute("class", "moveLeft");
         settingsPage.setAttribute("class", "moveLeft");
 
@@ -15,14 +15,15 @@ document.addEventListener('DOMContentLoaded', function () {
     document.getElementById("backArrow").addEventListener("click", function() {
         mainPage.setAttribute("class", "moveRight");
         settingsPage.setAttribute("class", "moveRight");
-    }); 
-    
+    });
+
     let homeToggle = document.getElementById("homeToggle");
     let storeToggle = document.getElementById("storeToggle");
     let gameToggle = document.getElementById("gameToggle");
     let ccToggle = document.getElementById("ccToggle");
+    let captureToggle = document.getElementById("captureToggle");
 
-    chrome.storage.local.get({"rpcHomeOn": true, "rpcStoreOn": true, "rpcGameOn": true, "rpcCCOn": false}, function(items) {
+    chrome.storage.local.get({"rpcHomeOn": true, "rpcCaptureOn": true, "rpcStoreOn": true, "rpcGameOn": true, "rpcCCOn": false}, function(items) {
         if (items.rpcHomeOn) {
             homeToggle.setAttribute("src", "/assets/icon128.png");
         }
@@ -38,6 +39,10 @@ document.addEventListener('DOMContentLoaded', function () {
         if (items.rpcCCOn) {
             ccToggle.setAttribute("src", "/assets/icon128.png");
         }
+
+        if (items.rpcCaptureOn) {
+            captureToggle.setAttribute("src", "/assets/icon128.png");
+        }
     });
 
     homeToggle.addEventListener("click", function() {
@@ -47,6 +52,16 @@ document.addEventListener('DOMContentLoaded', function () {
         } else {
             chrome.storage.local.set({rpcHomeOn: true});
             homeToggle.setAttribute("src", "/assets/icon128.png");
+        }
+    });
+
+    captureToggle.addEventListener("click", function() {
+        if (captureToggle.getAttribute("src") === "/assets/icon128.png") {
+            chrome.storage.local.set({rpcCaptureOn: false});
+            captureToggle.setAttribute("src", "/assets/rpcOff.png");
+        } else {
+            chrome.storage.local.set({rpcCaptureOn: true});
+            captureToggle.setAttribute("src", "/assets/icon128.png");
         }
     });
 


### PR DESCRIPTION
**Changes**:

* Chromecast T1 support 
-- **Note**: This uses the game id from main image/image w/ play button on Stadia home page. Without a refresh between starting/changing games, a T1 game might temporarily display as T3. I've seen up to 1 minute. 
-- Manually refresh if impatient. ~Timer is not reset when switching from T3 to T1 for same game since large image title does not change (👍) IF you do not manually refresh the page.~ <- This may not be true now that I'm checking description text also to reset counter when viewing captures
* Game start/stop via Chromecast/Android now resets the counter
* Games that are not present in GamesDB will now display whether using the Chromecast or not
* Large image text will now always display title of currently played game
* Moved small images around so that Chromecast/Pixel and Chrome are more clearly defined; Chrome logo is used only when truly playing/browsing in Chrome (when `ccOn` is enabled)
* Renamed statuses / personal preference
* Renamed addt'l large image titles / personal preference
* Decreased word wrap allowance (**Note**: Some things will still show ellipses...but not wrap with this change. I think that looks better than forcing some of the shorter titles to two lines. Example is "Viewing Cyberpunk 2077" when in the store)
* Added fallback for setting title of game being viewed in store -- e.g., Cyberpunk has multiple skus/bundles are a thing, and some games aren't in gamesDB yet
* Added toggle for `tabUrl.includes("/captures")` RPC; includes capture viewing on home page
* Change 'Pixel' to 'Mobile' since iOS and other Androids are now supported -- **To do:** Update wiki with same change

-----

**New setting**:

* ![image](https://user-images.githubusercontent.com/6219998/103323791-41874300-49f9-11eb-98fa-851bc88f8e5d.png)

**Home large image text is always 'Stadia Home'**:

* ![image](https://user-images.githubusercontent.com/6219998/103164500-e539de80-47c0-11eb-9938-cca65ec3a8c2.png)


**Store home _and_ viewing game in store, large image text is always 'Stadia Store':**

* ![image](https://user-images.githubusercontent.com/6219998/103164491-c20f2f00-47c0-11eb-88b1-6cc6b3d8bc3c.png)

**Browsing or viewing captures, large image text is always 'Stadia Captures' (unless viewing on home page--where it stays 'Stadia Home'):**
* ![image](https://user-images.githubusercontent.com/6219998/103320847-d5eaa900-49eb-11eb-8ed2-52a1ac158817.png)


**Large image text will always be game title:**
* ![image](https://user-images.githubusercontent.com/6219998/103164363-48c30c80-47bf-11eb-94f2-9f0bb3331b73.png)

**Small image titles:**
* Playing in Chrome (or in the Store): 
![image](https://user-images.githubusercontent.com/6219998/103164374-6abc8f00-47bf-11eb-8371-917c9219ea5f.png)
* Playing on Chromecast/game _with_ custom app/image:  
![image](https://user-images.githubusercontent.com/6219998/103164386-89bb2100-47bf-11eb-8306-8ad4f894b70f.png)
* Playing on Chromecast/game _without_ custom app/image (no small image text--could change to 'Online' or something but seems redundant): 
![image](https://user-images.githubusercontent.com/6219998/103164300-3f857000-47be-11eb-9875-a653844bba5e.png)

**Home:**
* chromecast (ccOn enabled):
![image](https://user-images.githubusercontent.com/6219998/103164240-963e7a00-47bd-11eb-8338-2ce797d11afc.png)
* chrome (ccOn disabled):
![image](https://user-images.githubusercontent.com/6219998/103164778-48794000-47c4-11eb-827f-5d26274c37cd.png)

**T1:**
* chromecast:
![image](https://user-images.githubusercontent.com/6219998/103164268-efa6a900-47bd-11eb-9418-923f34edb47c.png)
* chrome:
![image](https://user-images.githubusercontent.com/6219998/103164257-ce45bd00-47bd-11eb-8306-4398f2f6bcf4.png)

**T2:**
* chromecast:
![image](https://user-images.githubusercontent.com/6219998/103164291-1fee4780-47be-11eb-968d-0805168a4121.png)
* chrome:
![image](https://user-images.githubusercontent.com/6219998/103164352-0a2d5200-47bf-11eb-9606-8cb61bc9c9ea.png)

**T3 (plus games not in GamesDB):**
* chromecast:
![image](https://user-images.githubusercontent.com/6219998/103164300-3f857000-47be-11eb-9875-a653844bba5e.png)
* chrome:
![image](https://user-images.githubusercontent.com/6219998/103164304-6643a680-47be-11eb-8e1f-0402733c6e0e.png)

**Store:**
* ![image](https://user-images.githubusercontent.com/6219998/103164813-bd4c7a00-47c4-11eb-9065-1b3fc2ce54e5.png)



**Viewing game in store:**
* Before word wrap change: ![image](https://user-images.githubusercontent.com/6219998/103164321-9c812600-47be-11eb-9f9b-52c6a2caa9a2.png)
* After word wrap change: ![image](https://user-images.githubusercontent.com/6219998/103164334-c63a4d00-47be-11eb-95f8-796564486f57.png)

**Browsing captures:**
* ![image](https://user-images.githubusercontent.com/6219998/103320807-b5225380-49eb-11eb-9e90-059487376875.png)

**Viewing a capture:** (via /home _or_ /captures)
* ![image](https://user-images.githubusercontent.com/6219998/103320817-bc496180-49eb-11eb-9809-7226d95fb5d6.png)